### PR TITLE
setting up properties when the class is stood up

### DIFF
--- a/dpm/api/clients.py
+++ b/dpm/api/clients.py
@@ -19,6 +19,7 @@ class DynamicPropertyManagementClient:
         self.doc_path = f"dpm-configs/{self.service}-{self.program}"
         self.firestore_client = firestore.Client()
         self.doc_ref = self.firestore_client.document(self.doc_path)
+        self.properties = self.doc_ref.get().to_dict()
         doc_watch = self.doc_ref.on_snapshot(on_snapshot)
 
     def get_dynamic_properties(self) -> Dict[str, str]:


### PR DESCRIPTION
DPM currently relies on on_snapshot() to propagate self.properties but I don't think that happens when you stand up the class, so you end up with empty properties until a snapshot happens; this addresses that case. @bsieber-mozilla @spiropulo 