### PR TITLE
Provision environment variables.

### DIFF
--- a/dpm/api/env.py
+++ b/dpm/api/env.py
@@ -3,6 +3,7 @@
 # file, You can obtain one at https://mozilla.org/MPL/2.0/.
 
 import logging
+import os
 from typing import Dict
 
 from . import clients
@@ -97,3 +98,14 @@ class Env:
                 "You must invoke initialize with the appropriate parameters"
             )
         return self.secrets_client.get_secret(key)
+
+    def to_env(self):
+        import json
+
+        properties = self.dpm_client.get_dynamic_properties()
+        for k, v in properties.items():
+            if isinstance(v, dict):
+                for _, v in v.items():
+                    os.environ[k] = v
+            else:
+                os.environ[k] = v

--- a/dpm/tests/unit/test_env.py
+++ b/dpm/tests/unit/test_env.py
@@ -1,3 +1,5 @@
+import os
+
 import pytest
 from unittest import mock
 
@@ -21,6 +23,13 @@ def test_Env(monkeypatch):
     assert environment != None
     assert environment.dpm_initialized
     assert not environment.secrets_initialized
+
+    _environ = dict(os.environ)
+    environment.dpm_initialized = True
+    environment.to_env()
+    assert "fake_key" in os.environ
+    os.environ.clear()
+    os.environ.update(_environ)
 
     # uninitialized call to get_property throws exception
     environment.dpm_initialized = False


### PR DESCRIPTION
This pull request (PR) allows for the usage of [Python Decouple](https://pypi.org/project/python-decouple/)'s [AutoConfig](https://github.com/mozilla/subhub/blob/7f921e0b23352a6b28c41ebb36c27e77cb31750e/src/shared/cfg.py#L83) to pull values from the environment after the initiation of the class from the caller.  This has the added benefit of being able to fail fast instead of deferring failure as after the instantiation of the class the configuration could be created to validate the provisioning of required configuration parameters.

A note, this PR is cut from my prior branch as a thought experiment based upon other use cases.

<!-- Reviewable:start -->
---
This change is [<img src="https://reviewable.io/review_button.svg" height="34" align="absmiddle" alt="Reviewable"/>](https://reviewable.io/reviews/mozilla-it/cloudconfig/52)
<!-- Reviewable:end -->
